### PR TITLE
PLAT-2909 Add support for custom IAM role policies

### DIFF
--- a/modules/cloudtrail-baseline/README.md
+++ b/modules/cloudtrail-baseline/README.md
@@ -14,6 +14,7 @@ Enable CloudTrail in all regions and deliver events to CloudWatch Logs. CloudTra
 | cloudwatch\_logs\_retention\_in\_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely. | string | `"365"` | no |
 | enabled | The boolean flag whether this module is enabled or not. No resources are created when set to false. | string | `"true"` | no |
 | iam\_role\_name | The name of the IAM Role to be used by CloudTrail to delivery logs to CloudWatch Logs group. | string | `"CloudTrail-CloudWatch-Delivery-Role"` | no |
+| iam\_role\_permissions\_boundary\_arn | ARN for a permissions boundary policy to apply to the delivery role. | string | `""` | no |
 | iam\_role\_policy\_name | The name of the IAM Role Policy to be used by CloudTrail to delivery logs to CloudWatch Logs group. | string | `"CloudTrail-CloudWatch-Delivery-Policy"` | no |
 | is\_organization\_trail | Specifies whether the trail is an AWS Organizations trail. Organization trails log events for the master account and all member accounts. Can only be created in the organization master account. | string | `"false"` | no |
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days. | string | `"10"` | no |

--- a/modules/cloudtrail-baseline/main.tf
+++ b/modules/cloudtrail-baseline/main.tf
@@ -31,6 +31,8 @@ resource "aws_iam_role" "cloudwatch_delivery" {
   name               = var.iam_role_name
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_delivery_assume_policy.json
 
+  permissions_boundary = var.iam_role_permissions_boundary_arn
+
   tags = var.tags
 }
 

--- a/modules/cloudtrail-baseline/variables.tf
+++ b/modules/cloudtrail-baseline/variables.tf
@@ -32,6 +32,11 @@ variable "iam_role_name" {
   default     = "CloudTrail-CloudWatch-Delivery-Role"
 }
 
+variable "iam_role_permissions_boundary_arn" {
+  description = "ARN for a permissions boundary policy to apply to the delivery role."
+  default     = ""
+}
+
 variable "iam_role_policy_name" {
   description = "The name of the IAM Role Policy to be used by CloudTrail to delivery logs to CloudWatch Logs group."
   default     = "CloudTrail-CloudWatch-Delivery-Policy"

--- a/modules/iam-baseline/README.md
+++ b/modules/iam-baseline/README.md
@@ -12,10 +12,14 @@
 |------|-------------|:----:|:-----:|:-----:|
 | allow\_users\_to\_change\_password | Whether to allow users to change their own password. | string | `"true"` | no |
 | aws\_account\_id | The AWS Account ID number of the account. | string | n/a | yes |
+| manager\_iam\_role\_enabled | Indicate if Terraform will create/update/delete the manager IAM role. | string | `"true"` | no |
 | manager\_iam\_role\_name | The name of the IAM Manager role. | string | `"IAM-Manager"` | no |
 | manager\_iam\_role\_policy\_name | The name of the IAM Manager role policy. | string | `"IAM-Manager-Policy"` | no |
+| manager\_iam\_role\_policy\_json | Custom json to use for the role policy. The default allows the (dis)association of users and groups. | string | `""` | no |
+| master\_iam\_role\_enabled | Indicate if Terraform will create/update/delete the master IAM role. | string | `"true"` | no |
 | master\_iam\_role\_name | The name of the IAM Master role. | string | `"IAM-Master"` | no |
 | master\_iam\_role\_policy\_name | The name of the IAM Master role policy. | string | `"IAM-Master-Policy"` | no |
+| master\_iam\_role\_policy\_json | TCustom json to use for the role policy. The default allows management of users, groups, and roles. | string | `""` | no |
 | max\_password\_age | The number of days that an user password is valid. | string | `"90"` | no |
 | minimum\_password\_length | Minimum length to require for user passwords. | string | `"14"` | no |
 | password\_reuse\_prevention | The number of previous passwords that users are prevented from reusing. | string | `"24"` | no |

--- a/modules/iam-baseline/main.tf
+++ b/modules/iam-baseline/main.tf
@@ -32,6 +32,8 @@ resource "aws_iam_role" "master" {
   name               = var.master_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.master_assume_policy.json
 
+  permissions_boundary = var.master_iam_role_permissions_boundary_arn
+
   tags = var.tags
 }
 
@@ -95,6 +97,8 @@ resource "aws_iam_role" "manager" {
   name               = var.manager_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.manager_assume_policy.json
 
+  permissions_boundary = var.manager_iam_role_permissions_boundary_arn
+
   tags = var.tags
 }
 
@@ -157,6 +161,8 @@ data "aws_iam_policy_document" "support_assume_policy" {
 resource "aws_iam_role" "support" {
   name               = var.support_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.support_assume_policy.json
+
+  permissions_boundary = var.support_iam_role_permissions_boundary_arn
 
   tags = var.tags
 }

--- a/modules/iam-baseline/main.tf
+++ b/modules/iam-baseline/main.tf
@@ -27,6 +27,8 @@ data "aws_iam_policy_document" "master_assume_policy" {
 }
 
 resource "aws_iam_role" "master" {
+  count = var.master_iam_role_enabled == "true" ? 1 : 0
+
   name               = var.master_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.master_assume_policy.json
 
@@ -69,10 +71,12 @@ data "aws_iam_policy_document" "master_policy" {
 }
 
 resource "aws_iam_role_policy" "master_policy" {
-  name = var.master_iam_role_policy_name
-  role = aws_iam_role.master.id
+  count = var.master_iam_role_enabled == "true" ? 1 : 0
 
-  policy = data.aws_iam_policy_document.master_policy.json
+  name = var.master_iam_role_policy_name
+  role = aws_iam_role.master[count.index].id
+
+  policy = var.master_iam_role_policy_json != "" ? var.master_iam_role_policy_json : data.aws_iam_policy_document.master_policy.json
 }
 
 data "aws_iam_policy_document" "manager_assume_policy" {
@@ -86,6 +90,8 @@ data "aws_iam_policy_document" "manager_assume_policy" {
 }
 
 resource "aws_iam_role" "manager" {
+  count = var.manager_iam_role_enabled == "true" ? 1 : 0
+
   name               = var.manager_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.manager_assume_policy.json
 
@@ -128,9 +134,11 @@ data "aws_iam_policy_document" "manager_policy" {
 }
 
 resource "aws_iam_role_policy" "manager_policy" {
+  count = var.manager_iam_role_enabled == "true" ? 1 : 0
+
   name   = var.manager_iam_role_policy_name
-  role   = aws_iam_role.manager.id
-  policy = data.aws_iam_policy_document.manager_policy.json
+  role   = aws_iam_role.manager[count.index].id
+  policy = var.manager_iam_role_policy_json != "" ? var.manager_iam_role_policy_json : data.aws_iam_policy_document.manager_policy.json
 }
 
 # --------------------------------------------------------------------------------------------------
@@ -157,4 +165,3 @@ resource "aws_iam_role_policy_attachment" "support_policy" {
   role       = aws_iam_role.support.id
   policy_arn = "arn:aws:iam::aws:policy/AWSSupportAccess"
 }
-

--- a/modules/iam-baseline/variables.tf
+++ b/modules/iam-baseline/variables.tf
@@ -2,6 +2,11 @@ variable "aws_account_id" {
   description = "The AWS Account ID number of the account."
 }
 
+variable "master_iam_role_enabled" {
+  description = "Indicate if Terraform will create/update/delete the manager IAM role."
+  default     = "true"
+}
+
 variable "master_iam_role_name" {
   description = "The name of the IAM Master role."
   default     = "IAM-Master"
@@ -12,6 +17,16 @@ variable "master_iam_role_policy_name" {
   default     = "IAM-Master-Policy"
 }
 
+variable "master_iam_role_policy_json" {
+  description = "Custom json to use for the role policy. The default allows management of users, groups, and roles."
+  default     = ""
+}
+
+variable "manager_iam_role_enabled" {
+  description = "Indicate if Terraform will create/update/delete the manager IAM role."
+  default     = "true"
+}
+
 variable "manager_iam_role_name" {
   description = "The name of the IAM Manager role."
   default     = "IAM-Manager"
@@ -20,6 +35,11 @@ variable "manager_iam_role_name" {
 variable "manager_iam_role_policy_name" {
   description = "The name of the IAM Manager role policy."
   default     = "IAM-Manager-Policy"
+}
+
+variable "manager_iam_role_policy_json" {
+  description = "Custom json to use for the role policy. The default allows the (dis)association of users and groups."
+  default     = ""
 }
 
 variable "support_iam_role_name" {
@@ -83,4 +103,3 @@ variable "tags" {
     "Terraform" = true
   }
 }
-

--- a/modules/iam-baseline/variables.tf
+++ b/modules/iam-baseline/variables.tf
@@ -22,6 +22,11 @@ variable "master_iam_role_policy_json" {
   default     = ""
 }
 
+variable "master_iam_role_permissions_boundary_arn" {
+  description = "Permissions boundary arn to attach to the master IAM role."
+  default     = ""
+}
+
 variable "manager_iam_role_enabled" {
   description = "Indicate if Terraform will create/update/delete the manager IAM role."
   default     = "true"
@@ -42,6 +47,11 @@ variable "manager_iam_role_policy_json" {
   default     = ""
 }
 
+variable "manager_iam_role_permissions_boundary_arn" {
+  description = "Permissions boundary arn to attach to the manager IAM role."
+  default     = ""
+}
+
 variable "support_iam_role_name" {
   description = "The name of the the support role."
   default     = "IAM-Support"
@@ -55,6 +65,11 @@ variable "support_iam_role_policy_name" {
 variable "support_iam_role_principal_arns" {
   type        = list
   description = "List of ARNs of the IAM principal elements by which the support role could be assumed."
+}
+
+variable "support_iam_role_permissions_boundary_arn" {
+  description = "Permissions boundary arn to attach to the support IAM role."
+  default     = ""
 }
 
 variable "max_password_age" {


### PR DESCRIPTION
Add support for custom policies for IAM-Manager and IAM-Master roles. Also allow us to completely disable roles so that we may manage them ourselves.

PLAT-2909